### PR TITLE
Add segmentation multilabel support

### DIFF
--- a/hybridnets/model.py
+++ b/hybridnets/model.py
@@ -14,10 +14,10 @@ def nms(dets, thresh):
 class ModelWithLoss(nn.Module):
     def __init__(self, model, debug=False):
         super().__init__()
-        self.criterion = FocalLoss()
-        self.seg_criterion1 = TverskyLoss(mode='multilabel', alpha=0.7, beta=0.3, gamma=4.0 / 3, from_logits=False)
-        self.seg_criterion2 = FocalLossSeg(mode='multilabel', alpha=0.25)
         self.model = model
+        self.criterion = FocalLoss()
+        self.seg_criterion1 = TverskyLoss(mode=self.model.seg_mode, alpha=0.7, beta=0.3, gamma=4.0 / 3, from_logits=False)
+        self.seg_criterion2 = FocalLossSeg(mode=self.model.seg_mode, alpha=0.25)
         self.debug = debug
 
     def forward(self, imgs, annotations, seg_annot, obj_list=None):
@@ -792,7 +792,7 @@ class Activation(nn.Module):
     def __init__(self, name, **params):
 
         super().__init__()
-
+        self._name = name
         if name is None or name == 'identity':
             self.activation = nn.Identity(**params)
         elif name == 'sigmoid':

--- a/projects/bdd100k.yml
+++ b/projects/bdd100k.yml
@@ -26,15 +26,16 @@ traffic_light_color: false
 
 
 seg_list: ['road',
-          'lane']
+           'lane']
+seg_multilabel: false  # a pixel can belong to multiple labels (i.e. lane line + underlying road)
 
 dataset:
-  dataroot: ./datasets/bdd100k
-  labelroot: ./datasets/data2/zwt/bdd/bdd100k/labels/100k
+  dataroot: ../../HybridNets/datasets/bdd100k
+  labelroot: ../../HybridNets/datasets/data2/zwt/bdd/bdd100k/labels/100k
   segroot:
   # must be in correct order with seg_list
-  - ./datasets/bdd_seg_gt
-  - ./datasets/bdd_lane_gt
+  - ../../HybridNets/datasets/bdd_seg_gt
+  - ../../HybridNets/datasets/bdd_lane_gt
   data_format: jpg
   flip: true
   hsv_h: 0.015

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,0 +1,3 @@
+BINARY_MODE: str = "binary"
+MULTICLASS_MODE: str = "multiclass"
+MULTILABEL_MODE: str = "multilabel"


### PR DESCRIPTION
Tested training / validating / inferencing (weight only trained for <5 epochs) with binary / multiclass / multilabel.

The only _breaking change_ is with FocalLossSeg, from `F.binary_cross_entropy_with_logits` to `F.binary_cross_entropy` because we already have activation in last layer. Check [this issue on segmentation_models.pytorch](https://github.com/qubvel/segmentation_models.pytorch/issues/612) for more detail. Other than that, everything should be identical to how the repo was if the user doesn't switch `seg_multilabel` on in `project.yml`.